### PR TITLE
Add token text color option

### DIFF
--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -22,6 +22,8 @@ public protocol TokenTextViewControllerDelegate: class {
     func tokenTextViewTextStorageIsUpdatingFormatting(_ sender: TokenTextViewController, text: String, searchRange: NSRange) -> [(attributes: [String:AnyObject], forRange: NSRange)]
     /// Allows to customize the background color for a token
     func tokenTextViewBackgroundColourForTokenRef(_ sender: TokenTextViewController, tokenRef: TokenReference) -> UIColor?
+    /// Allows to customize the foreground color for a token
+    func tokenTextViewForegroundColourForTokenRef(_ sender: TokenTextViewController, tokenRef: TokenReference) -> UIColor?
     /// Whether the last edit should cancel token editing
     func tokenTextViewShouldCancelEditingAtInsert(_ sender: TokenTextViewController, newText: String, inputText: String) -> Bool
     /// Whether content of type type can be pasted in the text view.
@@ -43,6 +45,10 @@ public extension TokenTextViewControllerDelegate {
     
     func tokenTextViewDidAddToken(_ sender: TokenTextViewController, tokenRef: TokenReference) -> () {
         // Empty default implementation
+    }
+    
+    func tokenTextViewForegroundColourForTokenRef(_ sender: TokenTextViewController, tokenRef: TokenReference) -> UIColor? {
+        return UIColor.white
     }
 }
 
@@ -661,6 +667,10 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
 
     func textStorageBackgroundColourForTokenRef(_ sender: TokenTextViewTextStorage, tokenRef: TokenReference) -> UIColor? {
         return delegate?.tokenTextViewBackgroundColourForTokenRef(self, tokenRef: tokenRef)
+    }
+    
+    func textStorageForegroundColourForTokenRef(_ sender: TokenTextViewTextStorage, tokenRef: TokenReference) -> UIColor? {
+        return delegate?.tokenTextViewForegroundColourForTokenRef(self, tokenRef: tokenRef)
     }
 
     // MARK: Token text management

--- a/Sources/TokenTextViewTextStorage.swift
+++ b/Sources/TokenTextViewTextStorage.swift
@@ -9,6 +9,7 @@ import UIKit
 protocol TokenTextViewTextStorageDelegate: class {
     func textStorageIsUpdatingFormatting(_ sender: TokenTextViewTextStorage, text: String, searchRange: NSRange) -> [(attributes: [String:AnyObject], forRange: NSRange)]?
     func textStorageBackgroundColourForTokenRef(_ sender: TokenTextViewTextStorage, tokenRef: TokenReference) -> UIColor?
+    func textStorageForegroundColourForTokenRef(_ sender: TokenTextViewTextStorage, tokenRef: TokenReference) -> UIColor?
 }
 
 class TokenTextViewTextStorage: NSTextStorage {
@@ -97,9 +98,12 @@ class TokenTextViewTextStorage: NSTextStorage {
         enumerateTokens(inRange: searchRange) { (tokenRef, tokenRange) -> ObjCBool in
             var tokenFormattingAttributes = [String:AnyObject]()
             if let backgroundColor = self.formattingDelegate?.textStorageBackgroundColourForTokenRef(self, tokenRef: tokenRef) {
-                tokenFormattingAttributes[NSForegroundColorAttributeName] = UIColor.white
                 tokenFormattingAttributes[NSBackgroundColorAttributeName] = backgroundColor
             }
+            if let foregroundColor = self.formattingDelegate?.textStorageForegroundColourForTokenRef(self, tokenRef: tokenRef) {
+                tokenFormattingAttributes[NSForegroundColorAttributeName] = foregroundColor
+            }
+            
             let formattingRange = self.displayRangeFromTokenRange(tokenRange)
             self.addAttributes(tokenFormattingAttributes, range: formattingRange)
 


### PR DESCRIPTION
This PR gives the option to customize the token text color by exposing an optional delegate method. The default token text color remains white if method not implemented.