### PR TITLE
Trim token text strings for tokenizeAllEditableText

### DIFF
--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -489,7 +489,10 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
         if range.length != 0 {
             let nsText = text as NSString
             replaceCharactersInRange(range, withString: "")
-            addToken(range.location, text: nsText.substring(with: range))
+            let textSubstring = nsText.substring(with: range).trimmingCharacters(in: .whitespaces)
+            if !textSubstring.isEmpty {
+                addToken(range.location, text: textSubstring)
+            }
         }
     }
     


### PR DESCRIPTION
When calling the `tokenizeAllEditableText` method, all added tokens will have their text trimmed. This prevents just whitespace or empty string tokens.