### PR TITLE
MBL-9583: Fix reseting format

### DIFF
--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -226,122 +226,7 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
         }
     }
 
-    // Enhanced debugging to track each layout event
-    private var layoutEventCounter = 0
-    private var lastFormattingStatus = false
 
-    open func layoutManagerDidInvalidateLayout(_ layoutManager: NSLayoutManager) {
-        layoutEventCounter += 1
-        let currentStatus = checkFormattingStatus()
-
-        print("[TokenUI] 🔄 Layout invalidation #\(layoutEventCounter)")
-        print("[TokenUI]    - Formatting BEFORE invalidation: \(currentStatus ? "✅" : "❌")")
-
-        if lastFormattingStatus && !currentStatus {
-            print("[TokenUI]    - ⚠️ FORMATTING LOST DURING THIS INVALIDATION!")
-        }
-
-        lastFormattingStatus = currentStatus
-    }
-
-    open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
-        let currentStatus = checkFormattingStatus()
-
-        print("[TokenUI] 📐 Layout completion #\(layoutEventCounter), finished: \(layoutFinishedFlag)")
-        print("[TokenUI]    - Formatting AFTER completion: \(currentStatus ? "✅" : "❌")")
-
-        if lastFormattingStatus && !currentStatus {
-            print("[TokenUI]    - ⚠️ FORMATTING LOST DURING THIS COMPLETION!")
-            // Immediately restore formatting
-            print("[TokenUI]    - 🔧 Attempting to restore formatting...")
-            updateTokenFormatting()
-        }
-
-        lastFormattingStatus = currentStatus
-    }
-
-    private func checkFormattingStatus() -> Bool {
-        let text = viewAsTextView.text ?? ""
-        let attributedText = viewAsTextView.attributedText
-
-        guard text.contains("google.com") || text.contains("#") else { return true }
-
-        let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
-        var hasFormatting = false
-        var colorInfo: [(String, NSRange)] = []
-
-        attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-            if let color = value as? UIColor {
-                // Get color description and check if it's different from default
-                let colorDesc = color.description
-                colorInfo.append((colorDesc, range))
-
-                // More flexible color detection - any non-black/gray color
-                var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-                if color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
-                    let isColorful = (red > 0.1 && green < red * 0.7 && blue < red * 0.7) ||  // Reddish
-                                    (green > 0.1 && red < green * 0.7 && blue < green * 0.7) ||  // Greenish
-                                    (blue > 0.1 && red < blue * 0.7 && green < blue * 0.7)      // Blueish
-
-                    if isColorful {
-                        hasFormatting = true
-                        print("[TokenUI]    - Found formatted color: R:\(red) G:\(green) B:\(blue) at range: \(range)")
-                        stop.pointee = true
-                    }
-                }
-            }
-        }
-
-        print("[TokenUI]    - All colors found: \(colorInfo)")
-        print("[TokenUI]    - Overall formatting status: \(hasFormatting ? "✅ Present" : "❌ Missing")")
-        return hasFormatting
-    }
-
-//    open func layoutManagerDidInvalidateLayout(_ layoutManager: NSLayoutManager) {
-//        print("🔄 Layout manager invalidated layout - this might strip formatting!")
-//    }
-//
-//    open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
-//        print("📐 Layout completed, finished: \(layoutFinishedFlag)")
-//
-//        // Check if formatting is lost after layout completion
-//        if layoutFinishedFlag {
-//            DispatchQueue.main.async { [weak self] in
-//                self?.debugFormattingAfterLayout()
-//            }
-//        }
-//    }
-//
-//    private func debugFormattingAfterLayout() {
-//        let text = viewAsTextView.text ?? ""
-//        let attributedText = viewAsTextView.attributedText
-//
-//        print("🎨 Post-layout formatting check:")
-//        print("   - Text: \(text.prefix(50))...")
-//
-//        if text.contains("#") || text.contains("http") {
-//            print("   - Text should have formatting")
-//
-//            // Simple check: count how many characters have foreground color attributes
-//            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
-//            var coloredCharCount = 0
-//
-//            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-//                if value != nil {
-//                    coloredCharCount += range.length
-//                }
-//            }
-//
-//            print("   - Characters with color attributes: \(coloredCharCount)/\(fullRange.length)")
-//
-//            if coloredCharCount == 0 {
-//                print("   - ❌ NO FORMATTING FOUND - triggering refresh")
-//                updateTokenFormatting()
-//            } else {
-//                print("   - ✅ Formatting still present")
-//            }
-//        }
-//    }
 
     @objc func preferredContentSizeChanged(_ notification: Notification) {
         tokenTextStorage.updateFormatting()
@@ -875,6 +760,32 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
             return false
         }
         return true
+    }
+
+    open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
+        if layoutFinishedFlag {
+            // Detect attribute consolidation (formatting loss)
+            let text = viewAsTextView.text ?? ""
+            let attributedText = viewAsTextView.attributedText
+
+            if text.contains("google.com") || text.contains("#") {
+                let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
+                var colorRanges: [NSRange] = []
+
+                // Count distinct color ranges
+                attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+                    if value != nil {
+                        colorRanges.append(range)
+                    }
+                }
+
+                // If we have only 1 color range covering entire text, formatting was consolidated
+                if colorRanges.count == 1 && colorRanges.first?.length == fullRange.length {
+                    print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
+                    updateTokenFormatting()
+                }
+            }
+        }
     }
 
     // MARK: TokenTextViewTextStorageDelegate

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -195,11 +195,35 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
             selector: #selector(TokenTextViewController.preferredContentSizeChanged(_:)),
             name: UIContentSizeCategory.didChangeNotification,
             object: nil)
+
+        // ADD THESE NEW OBSERVERS for automatic formatting refresh
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(TokenTextViewController.refreshFormattingAutomatically),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(TokenTextViewController.refreshFormattingAutomatically),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
     override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    @objc func refreshFormattingAutomatically() {
+        // Small delay to ensure view hierarchy is stable
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.forceRefreshFormatting()
+        }
     }
 
     @objc func preferredContentSizeChanged(_ notification: Notification) {
@@ -754,6 +778,17 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
 
     fileprivate func effectiveTokenDisplayText(_ originalText: String) -> String {
         return tokenTextStorage.effectiveTokenDisplayText(originalText)
+    }
+
+    private func forceRefreshFormatting() {
+        guard let textView = self.view as? UITextView else { return }
+
+        let textStorage = textView.textStorage
+
+        textStorage.beginEditing()
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        textStorage.edited(.editedAttributes, range: fullRange, changeInLength: 0)
+        textStorage.endEditing()
     }
 
 }

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -763,29 +763,60 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
     }
 
     open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
-        if layoutFinishedFlag {
-            // Detect attribute consolidation (formatting loss)
-            let text = viewAsTextView.text ?? ""
-            let attributedText = viewAsTextView.attributedText
+        guard layoutFinishedFlag else {
+            return
+        }
 
-            if text.contains("google.com") || text.contains("#") {
-                let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
-                var colorRanges: [NSRange] = []
+        let text = viewAsTextView.text ?? ""
+        let attributedText = viewAsTextView.attributedText
+        let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
 
-                // Count distinct color ranges
-                attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-                    if value != nil {
-                        colorRanges.append(range)
-                    }
-                }
-
-                // If we have only 1 color range covering entire text, formatting was consolidated
-                if colorRanges.count == 1 && colorRanges.first?.length == fullRange.length {
-                    print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
-                    updateTokenFormatting()
-                }
+        // Count distinct color ranges
+        var colorRanges: [NSRange] = []
+        attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+            if value != nil {
+                colorRanges.append(range)
             }
         }
+
+        // Check if attributes were consolidated (single color range = entire text)
+        let hasConsolidatedAttributes = colorRanges.count == 1 &&
+                                       colorRanges.first?.length == fullRange.length
+
+        guard hasConsolidatedAttributes else {
+            return
+        }
+        
+        // Ask delegate if this text should have formatting
+        if let expectedFormats = delegate?.tokenTextViewTextStorageIsUpdatingFormatting(self, text: text, searchRange: fullRange),
+           !expectedFormats.isEmpty {
+            print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
+            updateTokenFormatting()
+        }
+
+
+//        // Detect attribute consolidation (formatting loss)
+//        let text = viewAsTextView.text ?? ""
+//        let attributedText = viewAsTextView.attributedText
+//
+//        if text.contains("google.com") || text.contains("#") {
+//            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
+//            var colorRanges: [NSRange] = []
+//
+//            // Count distinct color ranges
+//            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+//                if value != nil {
+//                    colorRanges.append(range)
+//                }
+//            }
+//
+//            // If we have only 1 color range covering entire text, formatting was consolidated
+//            if colorRanges.count == 1 && colorRanges.first?.length == fullRange.length {
+//                print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
+//                updateTokenFormatting()
+//            }
+//        }
+
     }
 
     // MARK: TokenTextViewTextStorageDelegate

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -222,7 +222,7 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
     @objc func refreshFormattingAutomatically() {
         // Small delay to ensure view hierarchy is stable
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.forceRefreshFormatting()
+            self?.updateTokenFormatting()
         }
     }
 
@@ -778,17 +778,6 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
 
     fileprivate func effectiveTokenDisplayText(_ originalText: String) -> String {
         return tokenTextStorage.effectiveTokenDisplayText(originalText)
-    }
-
-    private func forceRefreshFormatting() {
-        guard let textView = self.view as? UITextView else { return }
-
-        let textStorage = textView.textStorage
-
-        textStorage.beginEditing()
-        let fullRange = NSRange(location: 0, length: textStorage.length)
-        textStorage.edited(.editedAttributes, range: fullRange, changeInLength: 0)
-        textStorage.endEditing()
     }
 
 }

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -226,51 +226,112 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
         }
     }
 
+    // Enhanced debugging to track each layout event
+    private var layoutEventCounter = 0
+    private var lastFormattingStatus = false
+
     open func layoutManagerDidInvalidateLayout(_ layoutManager: NSLayoutManager) {
-        print("🔄 Layout manager invalidated layout - this might strip formatting!")
+        layoutEventCounter += 1
+        let currentStatus = checkFormattingStatus()
+
+        print("[TokenUI] 🔄 Layout invalidation #\(layoutEventCounter)")
+        print("[TokenUI]    - Formatting BEFORE invalidation: \(currentStatus ? "✅" : "❌")")
+
+        if lastFormattingStatus && !currentStatus {
+            print("[TokenUI]    - ⚠️ FORMATTING LOST DURING THIS INVALIDATION!")
+        }
+
+        lastFormattingStatus = currentStatus
     }
 
     open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
-        print("📐 Layout completed, finished: \(layoutFinishedFlag)")
+        let currentStatus = checkFormattingStatus()
 
-        // Check if formatting is lost after layout completion
-        if layoutFinishedFlag {
-            DispatchQueue.main.async { [weak self] in
-                self?.debugFormattingAfterLayout()
-            }
+        print("[TokenUI] 📐 Layout completion #\(layoutEventCounter), finished: \(layoutFinishedFlag)")
+        print("[TokenUI]    - Formatting AFTER completion: \(currentStatus ? "✅" : "❌")")
+
+        if lastFormattingStatus && !currentStatus {
+            print("[TokenUI]    - ⚠️ FORMATTING LOST DURING THIS COMPLETION!")
+            // Immediately restore formatting
+            print("[TokenUI]    - 🔧 Attempting to restore formatting...")
+            updateTokenFormatting()
         }
+
+        lastFormattingStatus = currentStatus
     }
 
-    private func debugFormattingAfterLayout() {
+    private func checkFormattingStatus() -> Bool {
         let text = viewAsTextView.text ?? ""
         let attributedText = viewAsTextView.attributedText
 
-        print("🎨 Post-layout formatting check:")
-        print("   - Text: \(text.prefix(50))...")
+        guard text.contains("google.com") || text.contains("#") else { return true }
 
-        if text.contains("#") || text.contains("http") {
-            print("   - Text should have formatting")
+        let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
+        var hasFormatting = false
 
-            // Simple check: count how many characters have foreground color attributes
-            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
-            var coloredCharCount = 0
+        attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+            if let color = value as? UIColor {
+                var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+                color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
-            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-                if value != nil {
-                    coloredCharCount += range.length
+                // Check if it's a link color (typically blue-ish)
+                if blue > 0.5 && red < 0.3 && green < 0.3 {
+                    hasFormatting = true
+                    print("[TokenUI]    - Found link formatting at range: \(range)")
+                    stop.pointee = true
                 }
             }
-
-            print("   - Characters with color attributes: \(coloredCharCount)/\(fullRange.length)")
-
-            if coloredCharCount == 0 {
-                print("   - ❌ NO FORMATTING FOUND - triggering refresh")
-                updateTokenFormatting()
-            } else {
-                print("   - ✅ Formatting still present")
-            }
         }
+
+        print("[TokenUI]    - Overall formatting status: \(hasFormatting ? "✅ Present" : "❌ Missing")")
+        return hasFormatting
     }
+
+//    open func layoutManagerDidInvalidateLayout(_ layoutManager: NSLayoutManager) {
+//        print("🔄 Layout manager invalidated layout - this might strip formatting!")
+//    }
+//
+//    open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
+//        print("📐 Layout completed, finished: \(layoutFinishedFlag)")
+//
+//        // Check if formatting is lost after layout completion
+//        if layoutFinishedFlag {
+//            DispatchQueue.main.async { [weak self] in
+//                self?.debugFormattingAfterLayout()
+//            }
+//        }
+//    }
+//
+//    private func debugFormattingAfterLayout() {
+//        let text = viewAsTextView.text ?? ""
+//        let attributedText = viewAsTextView.attributedText
+//
+//        print("🎨 Post-layout formatting check:")
+//        print("   - Text: \(text.prefix(50))...")
+//
+//        if text.contains("#") || text.contains("http") {
+//            print("   - Text should have formatting")
+//
+//            // Simple check: count how many characters have foreground color attributes
+//            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
+//            var coloredCharCount = 0
+//
+//            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+//                if value != nil {
+//                    coloredCharCount += range.length
+//                }
+//            }
+//
+//            print("   - Characters with color attributes: \(coloredCharCount)/\(fullRange.length)")
+//
+//            if coloredCharCount == 0 {
+//                print("   - ❌ NO FORMATTING FOUND - triggering refresh")
+//                updateTokenFormatting()
+//            } else {
+//                print("   - ✅ Formatting still present")
+//            }
+//        }
+//    }
 
     @objc func preferredContentSizeChanged(_ notification: Notification) {
         tokenTextStorage.updateFormatting()

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -226,6 +226,52 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
         }
     }
 
+    open func layoutManagerDidInvalidateLayout(_ layoutManager: NSLayoutManager) {
+        print("🔄 Layout manager invalidated layout - this might strip formatting!")
+    }
+
+    open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
+        print("📐 Layout completed, finished: \(layoutFinishedFlag)")
+
+        // Check if formatting is lost after layout completion
+        if layoutFinishedFlag {
+            DispatchQueue.main.async { [weak self] in
+                self?.debugFormattingAfterLayout()
+            }
+        }
+    }
+
+    private func debugFormattingAfterLayout() {
+        let text = viewAsTextView.text ?? ""
+        let attributedText = viewAsTextView.attributedText
+
+        print("🎨 Post-layout formatting check:")
+        print("   - Text: \(text.prefix(50))...")
+
+        if text.contains("#") || text.contains("http") {
+            print("   - Text should have formatting")
+
+            // Simple check: count how many characters have foreground color attributes
+            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
+            var coloredCharCount = 0
+
+            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
+                if value != nil {
+                    coloredCharCount += range.length
+                }
+            }
+
+            print("   - Characters with color attributes: \(coloredCharCount)/\(fullRange.length)")
+
+            if coloredCharCount == 0 {
+                print("   - ❌ NO FORMATTING FOUND - triggering refresh")
+                updateTokenFormatting()
+            } else {
+                print("   - ✅ Formatting still present")
+            }
+        }
+    }
+
     @objc func preferredContentSizeChanged(_ notification: Notification) {
         tokenTextStorage.updateFormatting()
     }

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -195,38 +195,12 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
             selector: #selector(TokenTextViewController.preferredContentSizeChanged(_:)),
             name: UIContentSizeCategory.didChangeNotification,
             object: nil)
-
-        // ADD THESE NEW OBSERVERS for automatic formatting refresh
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(TokenTextViewController.refreshFormattingAutomatically),
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(TokenTextViewController.refreshFormattingAutomatically),
-            name: UIApplication.willEnterForegroundNotification,
-            object: nil
-        )
     }
 
     override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
     }
-
-    @objc func refreshFormattingAutomatically() {
-        // Small delay to ensure view hierarchy is stable
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.updateTokenFormatting()
-        }
-    }
-
-
 
     @objc func preferredContentSizeChanged(_ notification: Notification) {
         tokenTextStorage.updateFormatting()

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -763,60 +763,43 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
     }
 
     open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
-        guard layoutFinishedFlag else {
+        guard
+            layoutFinishedFlag,
+            let text = viewAsTextView.text
+        else {
             return
         }
 
-        let text = viewAsTextView.text ?? ""
         let attributedText = viewAsTextView.attributedText
         let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
 
         // Count distinct color ranges
-        var colorRanges: [NSRange] = []
-        attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-            if value != nil {
-                colorRanges.append(range)
+        let colorRanges: [NSRange] = {
+            var colorRanges: [NSRange] = []
+            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, _ in
+                if value != nil {
+                    colorRanges.append(range)
+                }
             }
-        }
+            return colorRanges
+        }()
 
-        // Check if attributes were consolidated (single color range = entire text)
-        let hasConsolidatedAttributes = colorRanges.count == 1 &&
-                                       colorRanges.first?.length == fullRange.length
+        // Check if attributes were consolidated
+        let hasConsolidatedAttributes = colorRanges.count == 1 && colorRanges.first?.length == fullRange.length
 
         guard hasConsolidatedAttributes else {
             return
         }
-        
+
         // Ask delegate if this text should have formatting
-        if let expectedFormats = delegate?.tokenTextViewTextStorageIsUpdatingFormatting(self, text: text, searchRange: fullRange),
-           !expectedFormats.isEmpty {
-            print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
-            updateTokenFormatting()
+        guard
+            let expectedFormats = delegate?.tokenTextViewTextStorageIsUpdatingFormatting(self, text: text, searchRange: fullRange),
+            !expectedFormats.isEmpty
+        else {
+            return
         }
 
-
-//        // Detect attribute consolidation (formatting loss)
-//        let text = viewAsTextView.text ?? ""
-//        let attributedText = viewAsTextView.attributedText
-//
-//        if text.contains("google.com") || text.contains("#") {
-//            let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
-//            var colorRanges: [NSRange] = []
-//
-//            // Count distinct color ranges
-//            attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
-//                if value != nil {
-//                    colorRanges.append(range)
-//                }
-//            }
-//
-//            // If we have only 1 color range covering entire text, formatting was consolidated
-//            if colorRanges.count == 1 && colorRanges.first?.length == fullRange.length {
-//                print("[TokenUI] 🔧 Detected attribute consolidation - restoring formatting")
-//                updateTokenFormatting()
-//            }
-//        }
-
+        updateTokenFormatting()
     }
 
     // MARK: TokenTextViewTextStorageDelegate

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -268,21 +268,31 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
 
         let fullRange = NSRange(location: 0, length: attributedText?.length ?? 0)
         var hasFormatting = false
+        var colorInfo: [(String, NSRange)] = []
 
         attributedText?.enumerateAttribute(.foregroundColor, in: fullRange, options: []) { value, range, stop in
             if let color = value as? UIColor {
-                var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
-                color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+                // Get color description and check if it's different from default
+                let colorDesc = color.description
+                colorInfo.append((colorDesc, range))
 
-                // Check if it's a link color (typically blue-ish)
-                if blue > 0.5 && red < 0.3 && green < 0.3 {
-                    hasFormatting = true
-                    print("[TokenUI]    - Found link formatting at range: \(range)")
-                    stop.pointee = true
+                // More flexible color detection - any non-black/gray color
+                var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+                if color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+                    let isColorful = (red > 0.1 && green < red * 0.7 && blue < red * 0.7) ||  // Reddish
+                                    (green > 0.1 && red < green * 0.7 && blue < green * 0.7) ||  // Greenish
+                                    (blue > 0.1 && red < blue * 0.7 && green < blue * 0.7)      // Blueish
+
+                    if isColorful {
+                        hasFormatting = true
+                        print("[TokenUI]    - Found formatted color: R:\(red) G:\(green) B:\(blue) at range: \(range)")
+                        stop.pointee = true
+                    }
                 }
             }
         }
 
+        print("[TokenUI]    - All colors found: \(colorInfo)")
         print("[TokenUI]    - Overall formatting status: \(hasFormatting ? "✅ Present" : "❌ Missing")")
         return hasFormatting
     }

--- a/Tests/TokenTextViewControllerTests.swift
+++ b/Tests/TokenTextViewControllerTests.swift
@@ -376,4 +376,98 @@ class TokenTextViewControllerTests: XCTestCase {
         XCTAssertEqual(tokenVC.tokenList.count, 0, "Make token editable with modified emoji, token list count")
         XCTAssertEqual(tokenVC.text, emoji, "Make token editable with modified emoji, text")
     }
+
+    // MARK: - Layout Manager Delegate Tests
+
+    func testLayoutManagerDidCompleteLayout_whenLayoutNotFinished_shouldNotQueryDelegate() {
+        /// Given
+        let tokenViewController = TokenTextViewController()
+        let mockDelegate = MockTokenTextViewControllerDelegate()
+        tokenViewController.delegate = mockDelegate
+        tokenViewController.text = "Check http://google.com"
+        mockDelegate.reset()
+
+        /// When
+        tokenViewController.layoutManager(NSLayoutManager(), didCompleteLayoutFor: nil, atEnd: false)
+
+        /// Then
+        XCTAssertFalse(mockDelegate.textStorageIsUpdatingFormattingCalled, "Should not query delegate when layout not finished")
+    }
+
+    func testLayoutManagerDidCompleteLayout_whenNoText_shouldNotQueryDelegate() {
+        /// Given
+        let tokenViewController = TokenTextViewController()
+        let mockDelegate = MockTokenTextViewControllerDelegate()
+        tokenViewController.delegate = mockDelegate
+        tokenViewController.text = nil
+
+        /// When
+        tokenViewController.layoutManager(NSLayoutManager(), didCompleteLayoutFor: nil, atEnd: true)
+
+        /// Then
+        XCTAssertFalse(mockDelegate.textStorageIsUpdatingFormattingCalled, "Should not query delegate when no text")
+    }
+
+    func testLayoutManagerDidCompleteLayout_whenEmptyExpectedFormats_shouldNotTriggerFormatting() {
+        /// Given
+        let tokenViewController = TokenTextViewController()
+        let mockDelegate = MockTokenTextViewControllerDelegate()
+        mockDelegate.expectedFormats = [] // No expected formats
+        tokenViewController.delegate = mockDelegate
+        tokenViewController.text = "Plain text with no formatting"
+
+        /// When
+        tokenViewController.layoutManager(NSLayoutManager(), didCompleteLayoutFor: nil, atEnd: true)
+
+        /// Then
+        XCTAssertTrue(mockDelegate.textStorageIsUpdatingFormattingCalled, "Should query delegate for expected formats")
+        XCTAssertEqual(mockDelegate.lastQueriedText, "Plain text with no formatting", "Should query with correct text")
+    }
+
+    func testLayoutManagerDidCompleteLayout_whenExpectedFormatsExist_shouldQueryDelegate() {
+        /// Given
+        let tokenViewController = TokenTextViewController()
+        let mockDelegate = MockTokenTextViewControllerDelegate()
+        mockDelegate.expectedFormats = [
+            (attributes: [.foregroundColor: UIColor.blue], forRange: NSRange(location: 6, length: 17))
+        ]
+        tokenViewController.delegate = mockDelegate
+        tokenViewController.text = "Check http://google.com"
+
+        /// When
+        tokenViewController.layoutManager(NSLayoutManager(), didCompleteLayoutFor: nil, atEnd: true)
+
+        /// Then
+        XCTAssertTrue(mockDelegate.textStorageIsUpdatingFormattingCalled, "Should query delegate for expected formats")
+        XCTAssertEqual(mockDelegate.lastQueriedText, "Check http://google.com", "Should query with correct text")
+        XCTAssertEqual(mockDelegate.lastQueriedRange, NSRange(location: 0, length: 23), "Should query with full range")
+    }
+}
+
+private class MockTokenTextViewControllerDelegate: TokenTextViewControllerDelegate {
+    var expectedFormats: [(attributes: [NSAttributedString.Key: Any], forRange: NSRange)] = []
+    var textStorageIsUpdatingFormattingCalled = false
+    var lastQueriedText: String?
+    var lastQueriedRange: NSRange?
+
+    func reset() {
+        textStorageIsUpdatingFormattingCalled = false
+        lastQueriedText = nil
+        lastQueriedRange = nil
+    }
+
+    func tokenTextViewTextStorageIsUpdatingFormatting(_ sender: TokenTextViewController, text: String, searchRange: NSRange) -> [(attributes: [NSAttributedString.Key: Any], forRange: NSRange)] {
+        textStorageIsUpdatingFormattingCalled = true
+        lastQueriedText = text
+        lastQueriedRange = searchRange
+        return expectedFormats
+    }
+
+    func tokenTextViewDidChange(_ sender: TokenTextViewController) {}
+    func tokenTextViewShouldChangeTextInRange(_ sender: TokenTextViewController, range: NSRange, replacementText text: String) -> Bool { return true }
+    func tokenTextViewDidSelectToken(_ sender: TokenTextViewController, tokenRef: TokenReference, fromRect rect: CGRect) {}
+    func tokenTextViewDidDeleteToken(_ sender: TokenTextViewController, tokenRef: TokenReference) {}
+    func tokenTextViewBackgroundColourForTokenRef(_ sender: TokenTextViewController, tokenRef: TokenReference) -> UIColor? { return nil }
+    func tokenTextViewForegroundColourForTokenRef(_ sender: TokenTextViewController, tokenRef: TokenReference) -> UIColor? { return nil }
+    func tokenTextViewShouldCancelEditingAtInsert(_ sender: TokenTextViewController, newText: String, inputText: String) -> Bool { return false }
 }


### PR DESCRIPTION
Fixes an issue where text formatting is reset when a view is presented on top of the `TokenTextViewController`(new VC, alert, etc.)