### PR TITLE
MBL-9633: Add delegate method to detect the current location of the cursor

### DIFF
--- a/Demo/Sources/ViewController.swift
+++ b/Demo/Sources/ViewController.swift
@@ -35,6 +35,8 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: TokenTextViewControllerDelegate {
+    func tokenTextViewDidChangeSelection(_ sender: TokenTextViewController, selectedRange: NSRange) {
+    }
 
     func tokenTextViewDidChange(_ sender: TokenTextViewController) {
     }

--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -9,6 +9,9 @@ public protocol TokenTextViewControllerDelegate: AnyObject {
     /// Called when text changes.
     func tokenTextViewDidChange(_ sender: TokenTextViewController)
 
+    /// Called when the cursor position changes (selection changed).
+    func tokenTextViewDidChangeSelection(_ sender: TokenTextViewController, selectedRange: NSRange)
+
     /// Whether an edit should be accepted.
     func tokenTextViewShouldChangeTextInRange(_ sender: TokenTextViewController, range: NSRange, replacementText text: String) -> Bool
 
@@ -44,6 +47,9 @@ public protocol TokenTextViewControllerDelegate: AnyObject {
 
 /// Default implementation for some `TokenTextViewControllerDelegate` methods.
 public extension TokenTextViewControllerDelegate {
+    /// Empty default implementation
+    func tokenTextViewDidChangeSelection(_ sender: TokenTextViewController, selectedRange: NSRange) {
+    }
 
     /// Default value of `false`.
     func tokenTextView(_: TokenTextViewController, shouldAcceptContentOfType type: PasteboardItemType) -> Bool {
@@ -668,6 +674,8 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
                 viewAsTextView.selectedRange = NSRange(location: adjustedSelectionStart, length: adjustedSelectionLength)
             }
         }
+
+        delegate?.tokenTextViewDidChangeSelection(self, selectedRange: viewAsTextView.selectedRange)
     }
 
     fileprivate func clampCursorLocationToToken(_ cursorLocation: Int) -> Int {


### PR DESCRIPTION
### Changes
* Adds delegate method to detect the current location of the cursor

Used demo project to log the current word under the cursor (deleted before committing the code)
<video src="https://github.com/user-attachments/assets/d2529057-1694-40de-8d6e-d7f7832c8237" width=70% />


