### PR TITLE
MBL-10097: Memory layout fixes

### DIFF
--- a/Sources/TokenTextViewController.swift
+++ b/Sources/TokenTextViewController.swift
@@ -151,6 +151,7 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
     fileprivate var inputModeHandler: TokenTextViewControllerInputModeHandler!
     fileprivate var textTappedHandler: ((UITapGestureRecognizer) -> Void)?
     fileprivate var inputIsSuspended = false
+    private var isReapplyingFormatting = false
 
     /// Initializer for `self`.
     required public init?(coder aDecoder: NSCoder) {
@@ -768,6 +769,7 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
 
     open func layoutManager(_ layoutManager: NSLayoutManager, didCompleteLayoutFor textContainer: NSTextContainer?, atEnd layoutFinishedFlag: Bool) {
         guard
+            !isReapplyingFormatting,
             layoutFinishedFlag,
             let text = viewAsTextView.text
         else {
@@ -803,7 +805,9 @@ open class TokenTextViewController: UIViewController, UITextViewDelegate, NSLayo
             return
         }
 
+        isReapplyingFormatting = true
         updateTokenFormatting()
+        isReapplyingFormatting = false
     }
 
     // MARK: TokenTextViewTextStorageDelegate

--- a/Sources/TokenTextViewTextStorage.swift
+++ b/Sources/TokenTextViewTextStorage.swift
@@ -73,14 +73,15 @@ class TokenTextViewTextStorage: NSTextStorage {
     }
 
     func updateFormatting() {
-        // Dummy edit to trigger updating all attributes
+        let fullRange = NSRange(location: 0, length: self.length)
         self.beginEditing()
-        self.edited(.editedAttributes, range: NSRange(location: 0, length: 0), changeInLength: 0)
+        self.edited(.editedAttributes, range: fullRange, changeInLength: 0)
         self.dynamicTextNeedsUpdate = true
         self.endEditing()
     }
 
     fileprivate func applyFormattingAttributesToRange(_ searchRange: NSRange) {
+        beginEditing()
 
         // Set default attributes of edited range
         addAttribute(.foregroundColor, value: textColor, range: searchRange)
@@ -119,6 +120,8 @@ class TokenTextViewTextStorage: NSTextStorage {
                 }
             }
         }
+
+        endEditing()
     }
 
     fileprivate func fixDumQuotes() {


### PR DESCRIPTION
Each addAttribute call was triggering a separate layout pass. The layout manager would see half-finished formatting (all one color), think formatting was lost, and restart the whole process — creating an infinite loop that ate 2.8 GB of memory.

Wrapping all the attribute changes in beginEditing()/endEditing() batches them into a single layout pass, so the layout manager only sees the final result with proper formatting already applied.

I was seeing in the app before that memory kept climbing as I was using the app, now it's sitting around 100mb

#### BEFORE

https://github.com/user-attachments/assets/e0e829b7-4a77-4ed8-b590-7642ade01c6c

Open this post, click edit, the app goes unresponsive, then crashes

Memory usage spiked to 2.8 GB

#### AFTER 

Open post everything loads fine

https://github.com/user-attachments/assets/48264411-045f-4692-b99b-99dd70762e45

Memory usage stays around 100mb

<img width="754" height="763" alt="Screenshot 2026-03-10 at 2 43 04 PM" src="https://github.com/user-attachments/assets/603f16e6-e585-45c4-bc9a-0f407e485c08" />



